### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RAG Documentation MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@hannesrudolph/mcp-ragdocs)](https://smithery.ai/server/@hannesrudolph/mcp-ragdocs)
+
 An MCP server implementation that provides tools for retrieving and processing documentation through vector search, enabling AI assistants to augment their responses with relevant documentation context.
 
 ## Features
@@ -83,6 +85,14 @@ You'll need to provide values for the following environment variables:
 - `OPENAI_API_KEY`: Your OpenAI API key for embeddings generation
 - `QDRANT_URL`: URL of your Qdrant vector database instance
 - `QDRANT_API_KEY`: API key for authenticating with Qdrant
+
+### Installing via Smithery
+
+To install RAG Documentation for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@hannesrudolph/mcp-ragdocs):
+
+```bash
+npx -y @smithery/cli install @hannesrudolph/mcp-ragdocs --client claude
+```
 
 ## License
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install RAG Documentation for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@hannesrudolph/mcp-ragdocs

Let me know if any tweaks have to be made!